### PR TITLE
book browse bug fix

### DIFF
--- a/app/models/FlatBook.php
+++ b/app/models/FlatBook.php
@@ -520,7 +520,10 @@ class FlatBook extends Eloquent {
 		$last_query = end($queries);
 		var_dump($last_query);*/
 
-		return $books;
+		$booksData['data'] = $books->getItems();
+		$booksData['paginationLinks'] = (string) $books->links();
+
+		return $booksData;
 	}
 
 


### PR DESCRIPTION
results were being returned for caching when browsing without filter.
for this the bookindex view was changed.
however filtered results were not being sent in this new structure,
bombing the updated view. changed the result sent by flatbook.filtered
to new structure
